### PR TITLE
Move to new wire syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ cd <service name>
 ```
 
 ### Install Packages
+```
+# INTERNAL-ONLY. Remove 'yarn link' when current SDK published to NPM.
+yarn link "@wirelineio/sdk"
+```
 
 ```
-yarn link "@wirelineio/sdk"
 yarn install
 ```
 
@@ -65,11 +68,11 @@ Edit service.yml and stack.yml and change the service and stack names.
 ## Service Register
 
 ```
-$ wrl build
+$ wire build
 ```
 
 ```
-$ wrl service register --domain example.com
+$ wire service register --domain example.com
 
 Domain           Name                            Version         Content Hash                                                            Versions
 ---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -79,7 +82,7 @@ example.com      service-template                0.0.1           52cdbe12f3119fb
 ## Stack Deploy
 
 ```
-$ wrl stack deploy
+$ wire stack deploy
 
 Name                            Service                         Version         Status          Content Hash                                                            Endpoint
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -87,7 +90,7 @@ my-deployment                   wrn::service-template           0.0.1           
 ```
 
 ```
-$ wrl stack deploy
+$ wire stack deploy
 
 Name                            Service                         Version         Status          Content Hash                                                            Endpoint
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/handler.js
+++ b/handler.js
@@ -13,8 +13,8 @@ module.exports = {
   test: Wireline.exec(async (event, context, response) => {
     let { name='Alice' } = event.queryStringParameters || {};
 
-    response.send({
+    return {
       message: `Hello ${name}`
-    });
+    };
   })
 };


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160032920
Per Rich's recent CLI email
```
3). Please update the hello world MD file so that it is up-to-date: it should be written for external users: e.g., 

-  "wire" is the new cli name. 
- It should be installed from npm (make public). 
- The function signature should NOT have a response param (just return the value). 
- Any INTERNAL-ONLY notes/hacks should be marked up explicitly (e.g., ``` blocks that are clearly visible and can be removed once things are working).
``